### PR TITLE
Add Group Vibe Frontend

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -135,23 +135,27 @@ io.on("connection", (socket) => {
   });
 
   socket.on("confusedVote", async (data) => {
-    const GroupVibeCollection = "Placeholder"
-    await GroupVibeCollection.updateOneByKeyword(
+    const GroupVibeCollectionNOTREAL = "Is a Placeholder Collection"
+    const updateOneNOTREAL = "Is A Placeholder Function Within Collection"
+    // updateOneNOTREAL should take in a reaction, username, and chatroomKey and update the counts for the emojis and handle one user voting and handling toggling. In the end, it should return a json object like {happy: #count, confused: #count}
+    const totalCounts = await GroupVibeCollectionNOTREAL.updateOneNOTREAL(
       data.reaction,
       data.user,
       data.chatroomKey
     );
-    socket.to(data.roomName).emit("confusedVote:received", data);
+    socket.to(data.roomName).emit("confusedVote:received", totalCounts);
   });
 
   socket.on("happyVote", async (data) => {
-    const GroupVibeCollection = "Placeholder"
-    await GroupVibeCollection.updateOneByKeyword(
+    const GroupVibeCollectionNOTREAL = "Is a Placeholder Collection"
+    const updateOneNOTREAL = "Is A Placeholder Function Within Collection"
+    // updateOneNOTREAL should take in a reaction, username, and chatroomKey and update the counts for the emojis and handle one user voting and handling toggling. In the end, it should return a json object like {happy: #count, confused: #count}
+    const totalCounts = await GroupVibeCollectionNOTREAL.updateOneNOTREAL(
       data.reaction,
       data.user,
       data.chatroomKey
     );
-    socket.to(data.roomName).emit("happyVote:received", data);
+    socket.to(data.roomName).emit("happyVote:received", totalCounts);
   });
 
   socket.on("username", (data) => {

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -134,6 +134,26 @@ io.on("connection", (socket) => {
     socket.to(data.roomName).emit("message:received", data);
   });
 
+  socket.on("confusedVote", async (data) => {
+    const GroupVibeCollection = "Placeholder"
+    await GroupVibeCollection.updateOneByKeyword(
+      data.reaction,
+      data.user,
+      data.chatroomKey
+    );
+    socket.to(data.roomName).emit("confusedVote:received", data);
+  });
+
+  socket.on("happyVote", async (data) => {
+    const GroupVibeCollection = "Placeholder"
+    await GroupVibeCollection.updateOneByKeyword(
+      data.reaction,
+      data.user,
+      data.chatroomKey
+    );
+    socket.to(data.roomName).emit("happyVote:received", data);
+  });
+
   socket.on("username", (data) => {
     users[data.userId] = data.newUsername;
     socket.broadcast.emit("username:received", data);

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -143,8 +143,6 @@ io.on("connection", (socket) => {
       data.reaction,
       data.user,
     );
-    console.log("totalCounts")
-    console.log(totalCounts)
     socket.to(data.chatroomKey).emit("confusedVote:received", totalCounts);
   });
 
@@ -154,8 +152,6 @@ io.on("connection", (socket) => {
       data.reaction,
       data.user,
     );
-    console.log("totalCounts")
-    console.log(totalCounts)
     socket.to(data.chatroomKey).emit("happyVote:received", totalCounts);
   });
 

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -300,32 +300,22 @@ export default {
       });
     },
     voteConfused() {
-      // eslint-disable-next-line no-constant-condition
-      if ("true" === "true") {
-        this.confusedCount += 1;
-      } else {
-        // Emit Confused Reaction
-        const confusedVote = {
-          reaction: "confused",
-          user: this.username,
-          chatroomKey: this.joinedRoom,
-        };
-        this.socketInstance.emit("confusedVote", confusedVote); // send confused vote to others
-      }
+      // Emit Confused Reaction
+      const confusedVote = {
+        reaction: "confused",
+        user: this.username,
+        chatroomKey: this.joinedRoom,
+      };
+      this.socketInstance.emit("confusedVote", confusedVote); // send confused vote to others
     },
     async voteHappy() {
-      // eslint-disable-next-line no-constant-condition
-      if ("true" === "true") {
-        this.happyCount += 1;
-      } else {
-        // Emit Happy Reaction
-        const happyVote = {
-          reaction: "happy",
-          user: this.username,
-          chatroomKey: this.joinedRoom,
-        };
-        this.socketInstance.emit("happyVote", happyVote); // send happy vote to others
-      }
+      // Emit Happy Reaction
+      const happyVote = {
+        reaction: "happy",
+        user: this.username,
+        chatroomKey: this.joinedRoom,
+      };
+      this.socketInstance.emit("happyVote", happyVote); // send happy vote to others
     },
     async joinRoom(room) {
       this.socketInstance.emit("join-room", {

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -231,12 +231,12 @@ export default {
 
     // receive happyVote
     this.socketInstance.on("happyVote:received", (data) => {
-      this.happyCount = data.happyCount;
+      this.happyCount = data.happy;
     });
 
     // receive confusedVote
     this.socketInstance.on("confusedVote:received", (data) => {
-      this.confusedCount = data.confusedCount;
+      this.confusedCount = data.confused;
     });
 
     // reflect changed name

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -24,8 +24,34 @@
             class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
           >
             <img
-              src="https://img.icons8.com/ios-glyphs/30/000000/question--v1.png"
+              v-if="this.confusedCount === 0"
+              src="https://img.icons8.com/ios-glyphs/10/null/question--v1.png"
             />
+            <img
+              v-if="this.confusedCount === 1"
+              src="https://img.icons8.com/ios-glyphs/20/null/question--v1.png"
+            />
+            <img
+              v-if="this.confusedCount === 2"
+              src="https://img.icons8.com/ios-glyphs/30/null/question--v1.png"
+            />
+            <img
+              v-if="this.confusedCount === 3"
+              src="https://img.icons8.com/ios-glyphs/40/null/question--v1.png"
+            />
+            <img
+              v-if="this.confusedCount === 4"
+              src="https://img.icons8.com/ios-glyphs/50/null/question--v1.png"
+            />
+            <img
+              v-if="this.confusedCount === 5"
+              src="https://img.icons8.com/ios-glyphs/60/null/question--v1.png"
+            />
+            <img
+              v-if="this.confusedCount === 6"
+              src="https://img.icons8.com/ios-glyphs/70/null/question--v1.png"
+            />
+            <p>{{ this.confusedCount }}</p>
           </button>
           <button
             type="button"
@@ -36,6 +62,7 @@
             <img
               src="https://img.icons8.com/material-outlined/30/null/smiling.png"
             />
+            {{ this.happyCount }}
           </button>
         </div>
       </div>
@@ -237,78 +264,88 @@ export default {
     },
     async voteConfused() {
       console.log("You clicked confused");
-      const isProd = process.env.NODE_ENV === "production";
-      const postRequesturl =
-        (isProd
-          ? "https://quickchat-api-61040.herokuapp.com/"
-          : "http://localhost:3000/") + `api/groupvibes`;
-      const getRequesturl =
-        (isProd
-          ? "https://quickchat-api-61040.herokuapp.com/"
-          : "http://localhost:3000/") +
-        `api/groupvibes?keyword=${this.joinedRoom}`;
+      // eslint-disable-next-line no-constant-condition
+      if ("true" === "true") {
+        this.confusedCount += 1;
+      } else {
+        const isProd = process.env.NODE_ENV === "production";
+        const postRequesturl =
+          (isProd
+            ? "https://quickchat-api-61040.herokuapp.com/"
+            : "http://localhost:3000/") + `api/groupvibes`;
+        const getRequesturl =
+          (isProd
+            ? "https://quickchat-api-61040.herokuapp.com/"
+            : "http://localhost:3000/") +
+          `api/groupvibes?keyword=${this.joinedRoom}`;
 
-      // POST Request for Updating Confused Count
-      const options = {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      };
-      options.body = JSON.stringify({
-        reaction: "confused",
-        user: this.username,
-        chatroomKey: this.joinedRoom,
-      });
-      await fetch(postRequesturl, options);
+        // POST Request for Updating Confused Count
+        const options = {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        };
+        options.body = JSON.stringify({
+          reaction: "confused",
+          user: this.username,
+          chatroomKey: this.joinedRoom,
+        });
+        await fetch(postRequesturl, options);
 
-      // GET Request for Confused Count
+        // GET Request for Confused Count
 
-      try {
-        const r = await fetch(getRequesturl);
-        const res = await r.json();
-        if (!r.ok) {
-          throw new Error(res.error);
+        try {
+          const r = await fetch(getRequesturl);
+          const res = await r.json();
+          if (!r.ok) {
+            throw new Error(res.error);
+          }
+          this.confusedCount = res.confused;
+        } catch (e) {
+          console.log("Could not fetch counts for confused vibe:", e);
         }
-        this.confusedCount = res.confused;
-      } catch (e) {
-        console.log("Could not fetch counts for confused vibe:", e);
       }
     },
     async voteHappy() {
       console.log("You clicked happy");
-      const isProd = process.env.NODE_ENV === "production";
-      const postRequesturl =
-        (isProd
-          ? "https://quickchat-api-61040.herokuapp.com/"
-          : "http://localhost:3000/") + `api/groupvibes`;
-      const getRequesturl =
-        (isProd
-          ? "https://quickchat-api-61040.herokuapp.com/"
-          : "http://localhost:3000/") +
-        `api/groupvibes?keyword=${this.joinedRoom}`;
+      // eslint-disable-next-line no-constant-condition
+      if ("true" === "true") {
+        this.happyCount += 1;
+      } else {
+        const isProd = process.env.NODE_ENV === "production";
+        const postRequesturl =
+          (isProd
+            ? "https://quickchat-api-61040.herokuapp.com/"
+            : "http://localhost:3000/") + `api/groupvibes`;
+        const getRequesturl =
+          (isProd
+            ? "https://quickchat-api-61040.herokuapp.com/"
+            : "http://localhost:3000/") +
+          `api/groupvibes?keyword=${this.joinedRoom}`;
 
-      // POST Request for Updating Happy Count
-      const options = {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      };
-      options.body = JSON.stringify({
-        reaction: "happy",
-        user: this.username,
-        chatroomKey: this.joinedRoom,
-      });
-      await fetch(postRequesturl, options);
+        // POST Request for Updating Happy Count
+        const options = {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        };
+        options.body = JSON.stringify({
+          reaction: "happy",
+          user: this.username,
+          chatroomKey: this.joinedRoom,
+        });
+        await fetch(postRequesturl, options);
 
-      // GET Request for Happy Count
+        // GET Request for Happy Count
 
-      try {
-        const r = await fetch(getRequesturl);
-        const res = await r.json();
-        if (!r.ok) {
-          throw new Error(res.error);
+        try {
+          const r = await fetch(getRequesturl);
+          const res = await r.json();
+          if (!r.ok) {
+            throw new Error(res.error);
+          }
+          this.happyCount = res.happy;
+        } catch (e) {
+          console.log("Could not fetch counts for happy vibe:", e);
         }
-        this.happyCount = res.happy;
-      } catch (e) {
-        console.log("Could not fetch counts for happy vibe:", e);
       }
     },
     async joinRoom(room) {

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -229,6 +229,16 @@ export default {
       this.messages = this.messages.concat(data);
     });
 
+    // receive happyVote
+    this.socketInstance.on("happyVote:received", (data) => {
+      this.happyCount = data.happyCount;
+    });
+
+    // receive confusedVote
+    this.socketInstance.on("confusedVote:received", (data) => {
+      this.confusedCount = data.confusedCount;
+    });
+
     // reflect changed name
     this.socketInstance.on("username:received", (data) => {
       this.updateNameInMessages(data.userId, data.newUsername);
@@ -289,46 +299,18 @@ export default {
         return message;
       });
     },
-    async voteConfused() {
+    voteConfused() {
       // eslint-disable-next-line no-constant-condition
       if ("true" === "true") {
         this.confusedCount += 1;
       } else {
-        const isProd = process.env.NODE_ENV === "production";
-        const postRequesturl =
-          (isProd
-            ? "https://quickchat-api-61040.herokuapp.com/"
-            : "http://localhost:3000/") + `api/groupvibes`;
-        const getRequesturl =
-          (isProd
-            ? "https://quickchat-api-61040.herokuapp.com/"
-            : "http://localhost:3000/") +
-          `api/groupvibes?keyword=${this.joinedRoom}`;
-
-        // POST Request for Updating Confused Count
-        const options = {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        };
-        options.body = JSON.stringify({
+        // Emit Confused Reaction
+        const confusedVote = {
           reaction: "confused",
           user: this.username,
           chatroomKey: this.joinedRoom,
-        });
-        await fetch(postRequesturl, options);
-
-        // GET Request for Confused Count
-
-        try {
-          const r = await fetch(getRequesturl);
-          const res = await r.json();
-          if (!r.ok) {
-            throw new Error(res.error);
-          }
-          this.confusedCount = res.confused;
-        } catch (e) {
-          console.log("Could not fetch counts for confused vibe:", e);
-        }
+        };
+        this.socketInstance.emit("confusedVote", confusedVote); // send confused vote to others
       }
     },
     async voteHappy() {
@@ -336,41 +318,13 @@ export default {
       if ("true" === "true") {
         this.happyCount += 1;
       } else {
-        const isProd = process.env.NODE_ENV === "production";
-        const postRequesturl =
-          (isProd
-            ? "https://quickchat-api-61040.herokuapp.com/"
-            : "http://localhost:3000/") + `api/groupvibes`;
-        const getRequesturl =
-          (isProd
-            ? "https://quickchat-api-61040.herokuapp.com/"
-            : "http://localhost:3000/") +
-          `api/groupvibes?keyword=${this.joinedRoom}`;
-
-        // POST Request for Updating Happy Count
-        const options = {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        };
-        options.body = JSON.stringify({
+        // Emit Happy Reaction
+        const happyVote = {
           reaction: "happy",
           user: this.username,
           chatroomKey: this.joinedRoom,
-        });
-        await fetch(postRequesturl, options);
-
-        // GET Request for Happy Count
-
-        try {
-          const r = await fetch(getRequesturl);
-          const res = await r.json();
-          if (!r.ok) {
-            throw new Error(res.error);
-          }
-          this.happyCount = res.happy;
-        } catch (e) {
-          console.log("Could not fetch counts for happy vibe:", e);
-        }
+        };
+        this.socketInstance.emit("happyVote", happyVote); // send happy vote to others
       }
     },
     async joinRoom(room) {

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -17,7 +17,26 @@
         </div>
         <div class="mt-10">
           <h1 class="font-bold">Vibe</h1>
-          <p>some emojis</p>
+          <button
+            type="button"
+            id="confused"
+            @click="voteConfused"
+            class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
+          >
+            <img
+              src="https://img.icons8.com/ios-glyphs/30/000000/question--v1.png"
+            />
+          </button>
+          <button
+            type="button"
+            id="happy"
+            @click="voteHappy"
+            class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
+          >
+            <img
+              src="https://img.icons8.com/material-outlined/30/null/smiling.png"
+            />
+          </button>
         </div>
       </div>
       <footer v-if="joinedRoom.length !== 0" class="mt-auto py-10">
@@ -82,22 +101,6 @@
         <div
           class="flex items-center w-full px-3 py-2 rounded-lg dark:bg-gray-700"
         >
-          <button
-            type="button"
-            class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
-          >
-            <img
-              src="https://img.icons8.com/ios-glyphs/30/000000/question--v1.png"
-            />
-          </button>
-          <button
-            type="button"
-            class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
-          >
-            <img
-              src="https://img.icons8.com/material-outlined/30/null/smiling.png"
-            />
-          </button>
           <textarea
             id="chat"
             rows="1"
@@ -153,6 +156,8 @@ export default {
       rooms: ["apple"], // list of strings (room names)
       joinedRoom: "",
       scrolling: false,
+      confusedCount: 0,
+      happyCount: 0,
     };
   },
   created() {
@@ -229,6 +234,82 @@ export default {
         }
         return message;
       });
+    },
+    async voteConfused() {
+      console.log("You clicked confused");
+      const isProd = process.env.NODE_ENV === "production";
+      const postRequesturl =
+        (isProd
+          ? "https://quickchat-api-61040.herokuapp.com/"
+          : "http://localhost:3000/") + `api/groupvibes`;
+      const getRequesturl =
+        (isProd
+          ? "https://quickchat-api-61040.herokuapp.com/"
+          : "http://localhost:3000/") +
+        `api/groupvibes?keyword=${this.joinedRoom}`;
+
+      // POST Request for Updating Confused Count
+      const options = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      };
+      options.body = JSON.stringify({
+        reaction: "confused",
+        user: this.username,
+        chatroomKey: this.joinedRoom,
+      });
+      await fetch(postRequesturl, options);
+
+      // GET Request for Confused Count
+
+      try {
+        const r = await fetch(getRequesturl);
+        const res = await r.json();
+        if (!r.ok) {
+          throw new Error(res.error);
+        }
+        this.confusedCount = res.confused;
+      } catch (e) {
+        console.log("Could not fetch counts for confused vibe:", e);
+      }
+    },
+    async voteHappy() {
+      console.log("You clicked happy");
+      const isProd = process.env.NODE_ENV === "production";
+      const postRequesturl =
+        (isProd
+          ? "https://quickchat-api-61040.herokuapp.com/"
+          : "http://localhost:3000/") + `api/groupvibes`;
+      const getRequesturl =
+        (isProd
+          ? "https://quickchat-api-61040.herokuapp.com/"
+          : "http://localhost:3000/") +
+        `api/groupvibes?keyword=${this.joinedRoom}`;
+
+      // POST Request for Updating Happy Count
+      const options = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      };
+      options.body = JSON.stringify({
+        reaction: "happy",
+        user: this.username,
+        chatroomKey: this.joinedRoom,
+      });
+      await fetch(postRequesturl, options);
+
+      // GET Request for Happy Count
+
+      try {
+        const r = await fetch(getRequesturl);
+        const res = await r.json();
+        if (!r.ok) {
+          throw new Error(res.error);
+        }
+        this.happyCount = res.happy;
+      } catch (e) {
+        console.log("Could not fetch counts for happy vibe:", e);
+      }
     },
     async joinRoom(room) {
       this.socketInstance.emit("join-room", {

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -16,54 +16,81 @@
           <p>RoomView101</p>
         </div>
         <div class="mt-10">
-          <h1 class="font-bold">Vibe</h1>
-          <button
-            type="button"
-            id="confused"
-            @click="voteConfused"
-            class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
-          >
-            <img
-              v-if="this.confusedCount === 0"
-              src="https://img.icons8.com/ios-glyphs/10/null/question--v1.png"
-            />
-            <img
-              v-if="this.confusedCount === 1"
-              src="https://img.icons8.com/ios-glyphs/20/null/question--v1.png"
-            />
-            <img
-              v-if="this.confusedCount === 2"
-              src="https://img.icons8.com/ios-glyphs/30/null/question--v1.png"
-            />
-            <img
-              v-if="this.confusedCount === 3"
-              src="https://img.icons8.com/ios-glyphs/40/null/question--v1.png"
-            />
-            <img
-              v-if="this.confusedCount === 4"
-              src="https://img.icons8.com/ios-glyphs/50/null/question--v1.png"
-            />
-            <img
-              v-if="this.confusedCount === 5"
-              src="https://img.icons8.com/ios-glyphs/60/null/question--v1.png"
-            />
-            <img
-              v-if="this.confusedCount === 6"
-              src="https://img.icons8.com/ios-glyphs/70/null/question--v1.png"
-            />
-            <p>{{ this.confusedCount }}</p>
-          </button>
-          <button
-            type="button"
-            id="happy"
-            @click="voteHappy"
-            class="p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
-          >
-            <img
-              src="https://img.icons8.com/material-outlined/30/null/smiling.png"
-            />
-            {{ this.happyCount }}
-          </button>
+          <h1 class="font-bold">Group Vibe</h1>
+          <div class="flex flex-col justify-center content-center items-center">
+            <button
+              type="button"
+              id="confused"
+              @click="voteConfused"
+              class="mt-2 p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
+            >
+              <img
+                v-if="this.confusedCount === 0"
+                src="https://img.icons8.com/ios-glyphs/30/null/question--v1.png"
+              />
+              <img
+                v-if="this.confusedCount === 1"
+                src="https://img.icons8.com/ios-glyphs/35/null/question--v1.png"
+              />
+              <img
+                v-if="this.confusedCount === 2"
+                src="https://img.icons8.com/ios-glyphs/40/null/question--v1.png"
+              />
+              <img
+                v-if="this.confusedCount === 3"
+                src="https://img.icons8.com/ios-glyphs/50/null/question--v1.png"
+              />
+              <img
+                v-if="this.confusedCount === 4"
+                src="https://img.icons8.com/ios-glyphs/60/null/question--v1.png"
+              />
+              <img
+                v-if="this.confusedCount === 5"
+                src="https://img.icons8.com/ios-glyphs/70/null/question--v1.png"
+              />
+              <img
+                v-if="this.confusedCount >= 6"
+                src="https://img.icons8.com/ios-glyphs/80/null/question--v1.png"
+              />
+              <p v-if="this.confusedCount !== 0">{{ this.confusedCount }}</p>
+            </button>
+            <button
+              type="button"
+              id="happy"
+              @click="voteHappy"
+              class="mt-2 p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
+            >
+              <img
+                v-if="this.happyCount === 0"
+                src="https://img.icons8.com/material-outlined/30/null/smiling.png"
+              />
+              <img
+                v-if="this.happyCount === 1"
+                src="https://img.icons8.com/material-outlined/35/null/smiling.png"
+              />
+              <img
+                v-if="this.happyCount === 2"
+                src="https://img.icons8.com/material-outlined/40/null/smiling.png"
+              />
+              <img
+                v-if="this.happyCount === 3"
+                src="https://img.icons8.com/material-outlined/50/null/smiling.png"
+              />
+              <img
+                v-if="this.happyCount === 4"
+                src="https://img.icons8.com/material-outlined/60/null/smiling.png"
+              />
+              <img
+                v-if="this.happyCount === 5"
+                src="https://img.icons8.com/material-outlined/70/null/smiling.png"
+              />
+              <img
+                v-if="this.happyCount >= 6"
+                src="https://img.icons8.com/material-outlined/80/null/smiling.png"
+              />
+              <p v-if="this.happyCount !== 0">{{ this.happyCount }}</p>
+            </button>
+          </div>
         </div>
       </div>
       <footer v-if="joinedRoom.length !== 0" class="mt-auto py-10">
@@ -263,7 +290,6 @@ export default {
       });
     },
     async voteConfused() {
-      console.log("You clicked confused");
       // eslint-disable-next-line no-constant-condition
       if ("true" === "true") {
         this.confusedCount += 1;
@@ -306,7 +332,6 @@ export default {
       }
     },
     async voteHappy() {
-      console.log("You clicked happy");
       // eslint-disable-next-line no-constant-condition
       if ("true" === "true") {
         this.happyCount += 1;
@@ -360,7 +385,11 @@ export default {
         (isProd
           ? "https://quickchat-api-61040.herokuapp.com/"
           : "http://localhost:3000/") + `api/chatRooms?keyword=${room}`;
-      //   const url = `http://localhost:3000/api/chatRooms?keyword=${room}`;
+      const groupVibesCountURL =
+        (isProd
+          ? "https://quickchat-api-61040.herokuapp.com/"
+          : "http://localhost:3000/") +
+        `api/groupvibes?keyword=${this.joinedRoom}`;
 
       try {
         const r = await fetch(url);
@@ -373,6 +402,22 @@ export default {
         this.messages = res.messages;
       } catch (e) {
         console.log("Could not fetch messages:", e);
+      }
+
+      // Getting Initial Group Vibe Counts
+      try {
+        const r = await fetch(groupVibesCountURL);
+        const res = await r.json();
+        if (!r.ok) {
+          throw new Error(res.error);
+        }
+
+        this.happyCount = res.happy;
+        this.confusedCount = res.confused;
+      } catch (e) {
+        console.log("Could not fetch counts for group vibe:", e);
+        this.happyCount = 0;
+        this.confusedCount = 0;
       }
     },
     leaveRoom() {

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -25,31 +25,8 @@
               class="mt-2 p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
             >
               <img
-                v-if="this.confusedCount === 0"
-                src="https://img.icons8.com/ios-glyphs/30/null/question--v1.png"
-              />
-              <img
-                v-if="this.confusedCount === 1"
-                src="https://img.icons8.com/ios-glyphs/35/null/question--v1.png"
-              />
-              <img
-                v-if="this.confusedCount === 2"
-                src="https://img.icons8.com/ios-glyphs/40/null/question--v1.png"
-              />
-              <img
-                v-if="this.confusedCount === 3"
-                src="https://img.icons8.com/ios-glyphs/50/null/question--v1.png"
-              />
-              <img
-                v-if="this.confusedCount === 4"
-                src="https://img.icons8.com/ios-glyphs/60/null/question--v1.png"
-              />
-              <img
-                v-if="this.confusedCount === 5"
-                src="https://img.icons8.com/ios-glyphs/70/null/question--v1.png"
-              />
-              <img
-                v-if="this.confusedCount >= 6"
+                :width="20 + Math.min(6 * this.confusedCount, 60)"
+                :height="20 + Math.min(6 * this.confusedCount, 60)"
                 src="https://img.icons8.com/ios-glyphs/80/null/question--v1.png"
               />
               <p v-if="this.confusedCount !== 0">{{ this.confusedCount }}</p>
@@ -61,31 +38,8 @@
               class="mt-2 p-2 text-gray-500 rounded-lg cursor-pointer hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-600"
             >
               <img
-                v-if="this.happyCount === 0"
-                src="https://img.icons8.com/material-outlined/30/null/smiling.png"
-              />
-              <img
-                v-if="this.happyCount === 1"
-                src="https://img.icons8.com/material-outlined/35/null/smiling.png"
-              />
-              <img
-                v-if="this.happyCount === 2"
-                src="https://img.icons8.com/material-outlined/40/null/smiling.png"
-              />
-              <img
-                v-if="this.happyCount === 3"
-                src="https://img.icons8.com/material-outlined/50/null/smiling.png"
-              />
-              <img
-                v-if="this.happyCount === 4"
-                src="https://img.icons8.com/material-outlined/60/null/smiling.png"
-              />
-              <img
-                v-if="this.happyCount === 5"
-                src="https://img.icons8.com/material-outlined/70/null/smiling.png"
-              />
-              <img
-                v-if="this.happyCount >= 6"
+                :width="20 + Math.min(6 * this.happyCount, 60)"
+                :height="20 + Math.min(6 * this.happyCount, 60)"
                 src="https://img.icons8.com/material-outlined/80/null/smiling.png"
               />
               <p v-if="this.happyCount !== 0">{{ this.happyCount }}</p>

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -239,15 +239,11 @@ export default {
 
     // receive happyVote
     this.socketInstance.on("happyVote:received", (data) => {
-      console.log("receiving happyVote");
-      console.log(data);
       this.happyCount = data.happy;
     });
 
     // receive confusedVote
     this.socketInstance.on("confusedVote:received", (data) => {
-      console.log("receiving confusedVote");
-      console.log(data);
       this.confusedCount = data.confused;
     });
 
@@ -326,8 +322,7 @@ export default {
         chatroomKey: this.joinedRoom,
       };
       this.socketInstance.emit("confusedVote", confusedVote); // send confused vote to others
-      console.log("old confused counts");
-      console.log(this.confusedCount);
+
       if (this.userVotedConfused) {
         this.confusedCount -= 1;
       } else {
@@ -343,8 +338,7 @@ export default {
         chatroomKey: this.joinedRoom,
       };
       this.socketInstance.emit("happyVote", happyVote); // send happy vote to others
-      console.log("old happy counts");
-      console.log(this.happyCount);
+
       if (this.userVotedHappy) {
         this.happyCount -= 1;
       } else {


### PR DESCRIPTION
This handles issue #16 

This PR does the following: 
- Sets up the two emojis for confused and happy on the sidebar of main messaging view that scale in size depending on counts
- Sets up socket events for sending over confused and happy votes
- Initially gets the group vibe counts when one joins a room
- Updates the local group vibe counts when there is a vote received by a user