### PR TITLE
Switching Group Vibe frontend to use uid instead of username

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -189,7 +189,8 @@ io.on("connection", (socket) => {
   });
 
   socket.on("leave-room", async (data) => {
-    await GroupVibeCollection.deleteAllByUser(data.roomName, localStorage.uid);
+    const totalCounts = await GroupVibeCollection.deleteAllByUser(data.roomName, data.uid);
+    socket.to(data.roomName).emit("leftRoomGroupVibeUpdated", totalCounts);
     socket.leave(data.roomName);
   });
 

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -188,7 +188,7 @@ io.on("connection", (socket) => {
     socket.join(data.roomName);
   });
 
-  socket.on("leave-room", (data) => {
+  socket.on("leave-room", async (data) => {
     await GroupVibeCollection.deleteAllByUser(data.roomName, localStorage.uid);
     socket.leave(data.roomName);
   });

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -189,6 +189,7 @@ io.on("connection", (socket) => {
   });
 
   socket.on("leave-room", (data) => {
+    await GroupVibeCollection.deleteAllByUser(data.roomName, localStorage.uid);
     socket.leave(data.roomName);
   });
 
@@ -206,7 +207,7 @@ io.on("connection", (socket) => {
     const totalCounts = await GroupVibeCollection.updateOne(
       data.chatroomKey,
       data.reaction,
-      data.user
+      data.uid
     );
     socket.to(data.chatroomKey).emit("confusedVote:received", totalCounts);
   });
@@ -215,7 +216,7 @@ io.on("connection", (socket) => {
     const totalCounts = await GroupVibeCollection.updateOne(
       data.chatroomKey,
       data.reaction,
-      data.user
+      data.uid
     );
     socket.to(data.chatroomKey).emit("happyVote:received", totalCounts);
   });

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -421,7 +421,7 @@ export default {
       // Emit Confused Reaction
       const confusedVote = {
         reaction: "confused",
-        user: this.username,
+        uid: localStorage.uid,
         chatroomKey: this.joinedRoom,
       };
       this.socketInstance.emit("confusedVote", confusedVote); // send confused vote to others
@@ -437,7 +437,7 @@ export default {
       // Emit Happy Reaction
       const happyVote = {
         reaction: "happy",
-        user: this.username,
+        uid: localStorage.uid,
         chatroomKey: this.joinedRoom,
       };
       this.socketInstance.emit("happyVote", happyVote); // send happy vote to others

--- a/frontend/src/views/MainChatView.vue
+++ b/frontend/src/views/MainChatView.vue
@@ -261,6 +261,12 @@ export default {
       this.happyCount = data.happy;
     });
 
+    // receive updatedGroupVibeCounts
+    this.socketInstance.on("leftRoomGroupVibeUpdated", (data) => {
+      this.happyCount = data.happy;
+      this.confusedCount = data.confused;
+    });
+
     // receive confusedVote
     this.socketInstance.on("confusedVote:received", (data) => {
       this.confusedCount = data.confused;
@@ -508,6 +514,7 @@ export default {
     leaveRoom() {
       this.socketInstance.emit("leave-room", {
         roomName: this.joinedRoom,
+        uid: this.uid,
       });
       this.joinedRoom = "";
       this.$router.push("/");


### PR DESCRIPTION
This PR does the following:
- changes the parameter of user name string to a user unique id string that is in localStorage
- deletes all of the user group vibe reactions when a user leaves the room